### PR TITLE
Wait for both getAll and getAllKeys to resolve

### DIFF
--- a/prototype/implementation.mjs
+++ b/prototype/implementation.mjs
@@ -121,8 +121,10 @@ export class StorageArea {
         keysRequest.onerror = () => reject(keysRequest.error);
         valuesRequest.onerror = () => reject(valuesRequest.error);
 
-        valuesRequest.onsuccess = () => {
-          resolve(zip(keysRequest.result, valuesRequest.result));
+        keysRequest.onsuccess = valuesRequest.onsuccess = () => {
+          if (keysRequest.result && valuesRequest.result) {
+            resolve(zip(keysRequest.result, valuesRequest.result));
+          }
         };
       });
     });


### PR DESCRIPTION
Based on my understanding of the spec, it's not a safe assumption to assume that if one of `getAll()`/`getAllKeys()` succeeds, then both have succeded. This PR waits for both requests to succeed before resolving the promise.